### PR TITLE
Implement Windows, add tests, and other fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,42 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  gradle:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Build files
+        uses: actions/cache@v2
+        if: ${{ !startsWith(matrix.os, 'windows') }}
+        with:
+          path: |
+            ~/.konan
+            ~/.gradle
+          key: ${{ runner.os }}-${{ hashFiles('gradle.properties') }}
+      - uses: eskatos/gradle-command-action@v1
+        name: Test Windows Target
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        with:
+          arguments: clean jvmTest mingwX64Test
+      - uses: eskatos/gradle-command-action@v1
+        name: Test Apple Target
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        with:
+          arguments: clean jvmTest macosX64Test
+      - uses: eskatos/gradle-command-action@v1
+        name: Test Linux Target
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        with:
+          arguments: clean jvmTest linuxX64Test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,8 @@ version = "1.2"
 val isRunningInIde: Boolean = System.getProperty("idea.active")
     ?.toBoolean() == true
 
+val testApp: String? by extra
+
 repositories {
     mavenCentral()
 }
@@ -23,7 +25,6 @@ kotlin {
 
     // darwin macos code
     macosX64 {
-        val testApp: String? by extra
 
         if (testApp?.toBoolean() == true) {
             binaries {
@@ -35,15 +36,35 @@ kotlin {
     mingwX64()
 
     sourceSets {
-        val commonMain by getting
+        val commonMain by getting {
+            dependencies {
+                implementation(kotlin("test-common"))
+                implementation(kotlin("test-annotations-common"))
+            }
+        }
         val posixMain by creating {
             dependsOn(commonMain)
         }
         val macosX64Main by getting {
             dependsOn(posixMain)
+            if (testApp?.toBoolean() == true) {
+                kotlin.srcDirs("src/macosX64Runner/kotlin")
+            }
         }
         val linuxX64Main by getting {
             dependsOn(posixMain)
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(kotlin("test-junit"))
+            }
+        }
+        val jsTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(kotlin("test-js"))
+            }
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
         }
     }
 
-//    mingwX64("windows") // not supported yet
+    mingwX64()
 
     sourceSets {
         val commonMain by getting

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,4 @@ kotlin.js.generate.executable.default=false
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
+kotlin.native.ignoreDisabledTargets=true

--- a/src/commonMain/kotlin/File.common.kt
+++ b/src/commonMain/kotlin/File.common.kt
@@ -1,8 +1,8 @@
 package me.archinamon.fileio
 
 expect class File(pathname: String) {
-    fun getParent(): String
-    fun getParentFile(): File
+    fun getParent(): String?
+    fun getParentFile(): File?
 
     fun getName(): String
 

--- a/src/commonTest/kotlin/FileTests.kt
+++ b/src/commonTest/kotlin/FileTests.kt
@@ -1,0 +1,73 @@
+package me.archinamon.fileio
+
+import kotlin.test.*
+
+class FileTests {
+
+    @Test
+    fun testNonexistentRootFile() {
+        val testFile = File("testNonexistentRootFile.txt")
+
+        assertFalse(testFile.exists(), "file should not exist")
+        assertFalse(testFile.isDirectory(), "file should not be directory")
+        assertFalse(testFile.isFile(), "file should not be file")
+        assertNull(testFile.getParent(), "file should not have parent")
+        assertNull(testFile.getParentFile(), "file should not have parent file")
+
+        assertEquals("testNonexistentRootFile", testFile.nameWithoutExtension)
+    }
+
+    @Test
+    fun testFileCreateAndDelete() {
+        val testFolder = File("build/testNewDirectoryCreation")
+
+        assertTrue(testFolder.mkdirs(), "create directory failed")
+        assertTrue(testFolder.isDirectory(), "isDirectory check failed")
+
+        val testFile = File("build/testNewDirectoryCreation/test.txt")
+        assertTrue(testFile.createNewFile(), "create file failed")
+        assertTrue(testFile.exists(), "file should exist")
+        assertTrue(testFile.canRead(), "file should be readable")
+        assertTrue(testFile.canWrite(), "file should be writable")
+        assertTrue(testFile.isFile(), "file should be considered a file")
+        assertFalse(testFile.isDirectory(), "file should not be considered a directory")
+        assertTrue(testFile.delete(), "delete file failed")
+
+        assertTrue(testFolder.delete(), "delete directory failed")
+    }
+
+    @Test
+    fun testFileWriteAndRead() {
+        val testFolder = File("build/testFileWriteAndRead")
+        val testFile = File("build/testFileWriteAndRead/test.txt")
+
+        assertTrue(testFolder.mkdirs(), "failed to create directories")
+        assertTrue(testFile.createNewFile(), "failed to create file")
+
+        val message1 = "Hello,"
+        val message2 = " World!"
+        testFile.writeText(message1)
+
+        assertEquals(message1, testFile.readText(), "written text should match")
+
+        testFile.appendText(message2)
+
+        assertEquals(message1 + message2, testFile.readText(), "appended text should match")
+
+        assertTrue(testFile.delete(), "failed to cleanup test file")
+        assertTrue(testFolder.delete(), "failed to cleanup directory")
+    }
+
+    @Test
+    fun testFileLists() {
+        val testFolder = File("gradle/wrapper")
+        val listedFiles = testFolder.listFiles().sortedBy { it.getName().length }
+        val listedFileNames = testFolder.list().sortedBy { it.length }
+        assertEquals(2, listedFiles.size, "required two files")
+        assertEquals(2, listedFileNames.size, "required two file names")
+        assertEquals("gradle-wrapper.jar", listedFileNames.first())
+        assertEquals("gradle-wrapper.jar", listedFiles.first().getName())
+        assertEquals("gradle-wrapper.properties", listedFileNames[1])
+        assertEquals("gradle-wrapper.properties", listedFiles[1].getName())
+    }
+}

--- a/src/jsMain/kotlin/File.kt
+++ b/src/jsMain/kotlin/File.kt
@@ -12,14 +12,18 @@ actual class File constructor(jsfile: JsFile) {
         virtual = true
     }
 
-    actual fun getParent(): String {
-        return if ("/" in innerFile.name) {
-            innerFile.name.split("/").let { if (it.size > 1) it[it.lastIndex - 1] else it.last() }
-        } else innerFile.name
+    actual fun getParent(): String? {
+        return when {
+            !exists() -> null
+            "/" in innerFile.name -> innerFile.name
+                .split("/")
+                .let { if (it.size > 1) it[it.lastIndex - 1] else it.last() }
+            else -> innerFile.name
+        }
     }
 
-    actual fun getParentFile(): File {
-        return File(getParent())
+    actual fun getParentFile(): File? {
+        return getParent()?.run(::File)
     }
 
     actual fun getName(): String {

--- a/src/macosX64Runner/kotlin/runner.kt
+++ b/src/macosX64Runner/kotlin/runner.kt
@@ -8,7 +8,7 @@ fun main(args: Array<String>) = args.forEach { path ->
     if (path.endsWith("/")) {
         println("make directories... ${file.mkdirs()}")
     } else {
-        println("make directories... ${file.getParentFile().mkdirs()}")
+        println("make directories... ${file.getParentFile()?.mkdirs()}")
         println("creating file... ${file.createNewFile()}")
     }
 

--- a/src/mingwX64Main/kotlin/File.kt
+++ b/src/mingwX64Main/kotlin/File.kt
@@ -1,0 +1,316 @@
+package me.archinamon.fileio
+
+import kotlinx.cinterop.*
+import platform.windows.*
+
+// Difference between January 1, 1601 and January 1, 1970 in millis
+private const val EPOCH_DIFF = 11644473600000
+
+
+actual class File actual constructor(
+    private val pathname: String
+) {
+    private val fileSeparator
+        get() = if (Platform.osFamily == OsFamily.WINDOWS) "\\" else "/"
+
+    actual fun getParent(): String? {
+        return if (exists()) getAbsolutePath().substringBeforeLast(fileSeparator) else null
+    }
+
+    actual fun getParentFile(): File? {
+        return getParent()?.run(::File)
+    }
+
+    actual fun getName(): String {
+        return if (fileSeparator in pathname) {
+            pathname.split(fileSeparator).last(String::isNotBlank)
+        } else {
+            pathname
+        }
+    }
+
+    actual fun lastModified(): Long {
+        val handle = CreateFileA(
+            pathname,
+            GENERIC_READ,
+            0,
+            null,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            null
+        )
+        if (handle == INVALID_HANDLE_VALUE) {
+            return 0L
+        }
+
+        return try {
+            memScoped {
+                val ft = alloc<_FILETIME>()
+                val result = GetFileTime(handle, null, null, ft.ptr)
+                if (result == TRUE) {
+                    val st = alloc<_SYSTEMTIME>()
+                    val convertResult = FileTimeToSystemTime(ft.ptr, st.ptr)
+                    if (convertResult == TRUE) {
+                        val time = (ft.dwHighDateTime.toLong() shl 32) or ft.dwLowDateTime.toLong()
+                        (time / 10000) - EPOCH_DIFF
+                    } else 0L
+                } else 0L
+            }
+        } finally {
+            CloseHandle(handle)
+        }
+    }
+
+    actual fun mkdirs(): Boolean {
+        if (exists()) return false
+
+        if (getParentFile()?.exists() == false) {
+            getParentFile()?.mkdirs()
+        }
+
+        return SHCreateDirectoryExA(null, getAbsolutePath(), null) == ERROR_SUCCESS
+    }
+
+    actual fun createNewFile(): Boolean {
+        val handle = CreateFileA(
+            pathname,
+            GENERIC_WRITE,
+            FILE_SHARE_READ,
+            null,
+            CREATE_NEW,
+            FILE_ATTRIBUTE_NORMAL,
+            null
+        )
+
+        return try {
+            handle != INVALID_HANDLE_VALUE
+        } finally {
+            CloseHandle(handle)
+        }
+    }
+
+    actual fun isFile(): Boolean {
+        return GetFileAttributesA(pathname).let { attrs ->
+            attrs != INVALID_FILE_ATTRIBUTES &&
+                attrs and FILE_ATTRIBUTE_DIRECTORY.toUInt() == 0u
+        }
+    }
+
+    actual fun isDirectory(): Boolean {
+        return GetFileAttributesA(pathname).let { attrs ->
+            attrs != INVALID_FILE_ATTRIBUTES &&
+                (attrs and FILE_ATTRIBUTE_DIRECTORY.toUInt() != 0u)
+        }
+    }
+
+    actual fun getAbsolutePath(): String {
+        return if (pathname.startsWith(fileSeparator) || pathname.getOrNull(1) == ':') {
+            pathname
+        } else {
+            memScoped {
+                val bufLength = 200
+                val buf = allocArray<ByteVar>(bufLength)
+                val result = GetCurrentDirectoryA(bufLength.toUInt(), buf).toInt()
+                check(result != 0)
+                if (result > bufLength) {
+                    val retryBuf = allocArray<ByteVar>(result)
+                    GetCurrentDirectoryA(result.toUInt(), buf)
+                    check(result != 0)
+                    retryBuf.toKString()
+                } else {
+                    buf.toKString()
+                } + fileSeparator + pathname
+            }
+        }
+    }
+
+    actual fun exists(): Boolean {
+        return GetFileAttributesA(pathname) != INVALID_FILE_ATTRIBUTES
+    }
+
+    actual fun canRead(): Boolean {
+        val handle = CreateFileA(
+            pathname,
+            GENERIC_READ,
+            FILE_SHARE_READ,
+            null,
+            OPEN_EXISTING,
+            0,
+            null
+        )
+
+
+        return try {
+            handle != INVALID_HANDLE_VALUE
+        } finally {
+            CloseHandle(handle)
+        }
+    }
+
+    actual fun canWrite(): Boolean {
+        val handle = CreateFileA(
+            pathname,
+            GENERIC_WRITE,
+            FILE_SHARE_WRITE,
+            null,
+            OPEN_EXISTING,
+            0,
+            null
+        )
+
+        return try {
+            handle != INVALID_HANDLE_VALUE
+        } finally {
+            CloseHandle(handle)
+        }
+    }
+
+    actual fun list(): Array<String> = memScoped {
+        if (isFile()) return emptyArray()
+
+        val findData = alloc<WIN32_FIND_DATAA>()
+        val searchPath = if (pathname.endsWith(fileSeparator)) {
+            pathname
+        } else {
+            "$pathname${fileSeparator}"
+        } + "*"
+        val find = FindFirstFileA(searchPath, findData.ptr)
+        if (find == INVALID_HANDLE_VALUE) {
+            return emptyArray()
+        }
+
+        val files = mutableListOf<String>()
+        try {
+            while (FindNextFileA(find, findData.ptr) != 0) {
+                val fileName = findData.cFileName.toKString()
+                if (fileName != "..") {
+                    files.add(fileName)
+                }
+            }
+        } finally {
+            FindClose(find)
+        }
+
+        return files.toTypedArray()
+    }
+
+    actual fun listFiles(): Array<File> {
+        if (isFile()) return emptyArray()
+        val thisPath = getAbsolutePath().let { path ->
+            if (!path.endsWith(fileSeparator)) {
+                path + fileSeparator
+            } else path
+        }
+        return list()
+            .map { name -> File(thisPath + name) }
+            .toTypedArray()
+    }
+
+    actual fun delete(): Boolean = memScoped {
+        if (isFile()) return DeleteFileA(pathname) == TRUE
+
+        val fileOp = alloc<SHFILEOPSTRUCTA> {
+            hwnd = null
+            wFunc = FO_DELETE.toUInt()
+            pFrom = pathname.cstr.ptr
+            pTo = null
+            fFlags = (FOF_SILENT or FOF_NOCONFIRMATION or FOF_NOERRORUI).toUShort()
+            fAnyOperationsAborted = FALSE
+            hNameMappings = null
+            lpszProgressTitle = null
+        }
+
+        return SHFileOperationA(fileOp.ptr) == 0
+    }
+
+    internal fun writeBytes(bytes: ByteArray, access: Int) {
+        val handle = CreateFileA(
+            getAbsolutePath(),
+            access.toUInt(),
+            FILE_SHARE_WRITE,
+            null,
+            OPEN_EXISTING,
+            0,
+            null
+        )
+        if (handle == INVALID_HANDLE_VALUE) return
+
+        try {
+            memScoped {
+                val bytesWritten = alloc<UIntVar>()
+                bytes.usePinned { b ->
+                    WriteFile(
+                        handle,
+                        b.addressOf(0),
+                        bytes.size.toUInt(),
+                        bytesWritten.ptr,
+                        null
+                    )
+                }
+            }
+        } finally {
+            CloseHandle(handle)
+        }
+    }
+
+    override fun toString(): String {
+        return "File {\n" +
+            "path=${getAbsolutePath()}\n" +
+            "name=${getName()}\n" +
+            "exists=${exists()}\n" +
+            "canRead=${canRead()}\n" +
+            "canWrite=${canWrite()}\n" +
+            "isFile=${isFile()}\n" +
+            "isDirectory=${isDirectory()}\n" +
+            "lastModified=${lastModified()}\n" +
+            (if (isDirectory()) "files=[${listFiles().joinToString()}]" else "") +
+            "}"
+    }
+}
+
+actual val File.mimeType: String
+    get() = ""
+
+actual fun File.readBytes(): ByteArray = memScoped {
+    val handle = CreateFileA(
+        getAbsolutePath(),
+        GENERIC_READ,
+        FILE_SHARE_READ,
+        null,
+        OPEN_EXISTING,
+        0,
+        null
+    )
+    if (handle == INVALID_HANDLE_VALUE) return byteArrayOf()
+
+    try {
+        val fs = alloc<_LARGE_INTEGER>()
+        if (GetFileSizeEx(handle, fs.ptr) == TRUE) {
+            val size = (fs.HighPart.toUInt() shl 32) or fs.LowPart
+            val buf = allocArray<ByteVar>(size.toInt())
+            val bytesRead = alloc<UIntVar>()
+            if (ReadFile(handle, buf, size, bytesRead.ptr, null) == TRUE) {
+                buf.readBytes(bytesRead.value.toInt())
+            } else {
+                byteArrayOf()
+            }
+        } else {
+            byteArrayOf()
+        }
+    } finally {
+        CloseHandle(handle)
+    }
+}
+
+actual fun File.readText(): String {
+    return readBytes().toKString()
+}
+
+actual fun File.appendText(text: String) {
+    writeBytes(text.encodeToByteArray(), FILE_APPEND_DATA)
+}
+
+actual fun File.writeText(text: String) {
+    writeBytes(text.encodeToByteArray(), GENERIC_WRITE)
+}
+

--- a/src/posixMain/kotlin/File.kt
+++ b/src/posixMain/kotlin/File.kt
@@ -54,12 +54,12 @@ actual class File actual constructor(
     private val modeAppend = "a"
     private val modeRewrite = "w"
 
-    actual fun getParent(): String {
-        return getAbsolutePath().substringBeforeLast(fileSeparator)
+    actual fun getParent(): String? {
+        return if (exists()) getAbsolutePath().substringBeforeLast(fileSeparator) else  null
     }
 
-    actual fun getParentFile(): File {
-        return File(getParent())
+    actual fun getParentFile(): File? {
+        return getParent()?.run(::File)
     }
 
     actual fun getName(): String {
@@ -82,12 +82,10 @@ actual class File actual constructor(
     actual fun lastModified(): Long = modified(this)
 
     actual fun mkdirs(): Boolean {
-        if (!getParentFile().exists()) {
-            getParentFile().mkdirs()
-        }
+        if (exists()) return false
 
-        if (exists()) {
-            return true
+        if (getParentFile()?.exists() == false) {
+            getParentFile()?.mkdirs()
         }
 
         mkdir(pathname, (S_IRWXU or S_IRWXG or S_IRWXO).convert())

--- a/src/posixMain/kotlin/File.kt
+++ b/src/posixMain/kotlin/File.kt
@@ -47,7 +47,7 @@ actual class File actual constructor(
     private val pathname: String
 ) {
 
-    private val fileSaperator
+    private val fileSeparator
         get() = if (Platform.osFamily == OsFamily.WINDOWS) "\\" else "/"
 
     internal val modeRead = "r"
@@ -55,7 +55,7 @@ actual class File actual constructor(
     private val modeRewrite = "w"
 
     actual fun getParent(): String {
-        return getAbsolutePath().substringBeforeLast(fileSaperator)
+        return getAbsolutePath().substringBeforeLast(fileSeparator)
     }
 
     actual fun getParentFile(): File {
@@ -63,18 +63,18 @@ actual class File actual constructor(
     }
 
     actual fun getName(): String {
-        return if (fileSaperator in pathname) {
-            pathname.split(fileSaperator).last(String::isNotBlank)
+        return if (fileSeparator in pathname) {
+            pathname.split(fileSeparator).last(String::isNotBlank)
         } else {
             pathname
         }
     }
 
     actual fun getAbsolutePath(): String {
-        return if (!pathname.startsWith(fileSaperator)) {
+        return if (!pathname.startsWith(fileSeparator)) {
             memScoped {
                 getcwd(allocArray(FILENAME_MAX), FILENAME_MAX)
-                    ?.toKString() + fileSaperator + pathname
+                    ?.toKString() + fileSeparator + pathname
             }
         } else pathname
     }
@@ -158,15 +158,16 @@ actual class File actual constructor(
             .toTypedArray()
     }
 
-    actual fun listFiles(): Array<File> = list().map { name ->
+    actual fun listFiles(): Array<File> {
         val thisPath = getAbsolutePath().let { path ->
-            if (!path.endsWith(fileSaperator)) {
-                path + fileSaperator
+            if (!path.endsWith(fileSeparator)) {
+                path + fileSeparator
             } else path
         }
-
-        File(thisPath + name)
-    }.toTypedArray()
+        return list()
+            .map { name -> File(thisPath + name) }
+            .toTypedArray()
+    }
 
     actual fun delete(): Boolean {
         if (isDirectory()) {


### PR DESCRIPTION
Minor posix improvements
- Single call to `getAbsolutePath()` in listFiles
- Fix file separator typo

Implement Windows target

Add tests, CI workflow

I've made `getParent()` and `getParentFile()` nullable to account for JVM behavior noticed in the first test case.  There are also other inconsistencies like the last modification timestamp where, even on the JVM, different hosts will provide a different value (seconds or ms).  Type-aliasing `expect`ed types does not scale well beyond simple APIs, so in the future the JVM may need a wrapper class to introduce consistent behavior.  Since none of the current edge-cases bother my uses-case, I've left it as-is.

Here is the passing workflow from my fork https://github.com/DrewCarlson/native-file-io/runs/2707023193
When merged it would run on commits to master and for pull requests.